### PR TITLE
Update cilium-policy-verdicts-dashboard.json

### DIFF
--- a/dashboards/cilium-policy-verdicts/cilium-policy-verdicts-dashboard.json
+++ b/dashboards/cilium-policy-verdicts/cilium-policy-verdicts-dashboard.json
@@ -970,7 +970,7 @@
         "current": {},
         "datasource": {
           "type": "prometheus",
-          "uid": "prometheus"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "query_result(label_replace(hubble_policy_verdicts_total{direction=\"ingress\", destination_namespace=~\"$namespace\"}, \"workload\", \"$1\", \"destination\", \"(.+)\") OR label_replace(hubble_policy_verdicts_total{direction=\"egress\", source_namespace=~\"$namespace\"}, \"workload\", \"$1\", \"source\", \"(.+)\"))",
         "description": "The Kubernetes workload the Network Policies apply to",


### PR DESCRIPTION
This was an inconsistency which made it extremely difficult to override the `DS_PROMETHEUS` value in our Grafana instance when importing the dashboard with the following:

```yaml
        cilium-policy-verdict-dashboard:
          gnetId: 18015
          revision: 3
          datasource:
            - name: "DS_PROMETHEUS"
              value: Prometheus
```

Therefore the value wasn't being respected and would fail with an error on templating that the datasource did not exist


https://cilium.slack.com/archives/CQRL1EPAA/p1681097311036489

Signed-off-by: Michael Fornaro <20387402+xUnholy@users.noreply.github.com>
